### PR TITLE
fix: typo ignore

### DIFF
--- a/src/Rector/JwtAuthUpgradeRector.php
+++ b/src/Rector/JwtAuthUpgradeRector.php
@@ -363,7 +363,7 @@ final class JwtAuthUpgradeRector extends AbstractRector
         }
 
         if ($ignore !== null) {
-            $args[] = new Arg($ignore, name: new Identifier('ignnore'));
+            $args[] = new Arg($ignore, name: new Identifier('ignore'));
         }
 
         $pathObj = new New_(new Name(RequestPathRule::class), $args);

--- a/tests/Rector/JwtAuthUpgradeRector/Fixture/path_and_ignore.php.inc
+++ b/tests/Rector/JwtAuthUpgradeRector/Fixture/path_and_ignore.php.inc
@@ -18,6 +18,6 @@ namespace JimTools\JwtAuth\Test\Rector\JwtAuthUpgradeRector\Fixture;
 
 use JimTools\JwtAuth\Middleware\JwtAuthentication;
 
-$auth = new JwtAuthentication(new JimTools\JwtAuth\Options(), new JimTools\JwtAuth\Decoder\FirebaseDecoder(new JimTools\JwtAuth\Secret($_ENV['JWT_SECRET'], 'HS256')), [new JimTools\JwtAuth\Rules\RequestPathRule(path: ['/', '/api'], ignnore: ['/api/auth']), new JimTools\JwtAuth\Rules\RequestMethodRule()]);
+$auth = new JwtAuthentication(new JimTools\JwtAuth\Options(), new JimTools\JwtAuth\Decoder\FirebaseDecoder(new JimTools\JwtAuth\Secret($_ENV['JWT_SECRET'], 'HS256')), [new JimTools\JwtAuth\Rules\RequestPathRule(path: ['/', '/api'], ignore: ['/api/auth']), new JimTools\JwtAuth\Rules\RequestMethodRule()]);
 
 ?>


### PR DESCRIPTION
fixing typo with the rector rule where the Rules ignore aren't being correctly properly.

fixes #20