### PR TITLE
Upgrading firebase/php-jwt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
+        "ext-openssl": "*",
         "equip/dispatch": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.89",
         "laminas/laminas-diactoros": "^3.7",


### PR DESCRIPTION
Breaking change upgrading `firebase/php-jwt` to  `v7.0`, because of a potential security issue with users supplying a weak encryption key.

fixes #22 